### PR TITLE
Prevent live stream from jumping to start

### DIFF
--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -399,11 +399,11 @@ function PlaybackController() {
         if (!DVRWindow) return NaN;
         if (currentTime > DVRWindow.end) {
             actualTime = Math.max(DVRWindow.end - streamInfo.manifestInfo.minBufferTime * 2, DVRWindow.start);
-        } else if (currentTime + 0.250 < DVRWindow.start && DVRWindow.start - currentTime > DVRWindow.start - 31536000) {
+        } else if (currentTime + 0.250 < DVRWindow.start && DVRWindow.start - currentTime > DVRWindow.start - 315360000) {
             // Checking currentTime plus 250ms as the 'timeupdate' is fired with a frequency between 4Hz and 66Hz
             // https://developer.mozilla.org/en-US/docs/Web/Events/timeupdate
             // http://w3c.github.io/html/single-page.html#offsets-into-the-media-resource
-	    // Making also sure that difference between DVRWindow.start and currentTime reported by video element isn't bigger than 1y
+	    // Making also sure that difference between DVRWindow.start and currentTime reported by video element isn't bigger than 10 years
 	    // https://github.com/Dash-Industry-Forum/dash.js/issues/2993
             actualTime = DVRWindow.start;
         } else {

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -399,10 +399,12 @@ function PlaybackController() {
         if (!DVRWindow) return NaN;
         if (currentTime > DVRWindow.end) {
             actualTime = Math.max(DVRWindow.end - streamInfo.manifestInfo.minBufferTime * 2, DVRWindow.start);
-        } else if (currentTime + 0.250 < DVRWindow.start) {
+        } else if (currentTime + 0.250 < DVRWindow.start && DVRWindow.start - currentTime > DVRWindow.start - 31536000) {
             // Checking currentTime plus 250ms as the 'timeupdate' is fired with a frequency between 4Hz and 66Hz
             // https://developer.mozilla.org/en-US/docs/Web/Events/timeupdate
             // http://w3c.github.io/html/single-page.html#offsets-into-the-media-resource
+	    // Making also sure that difference between DVRWindow.start and currentTime reported by video element isn't bigger than 1y
+	    // https://github.com/Dash-Industry-Forum/dash.js/issues/2993
             actualTime = DVRWindow.start;
         } else {
             return currentTime;


### PR DESCRIPTION
This PR tries to fix issue described in https://github.com/Dash-Industry-Forum/dash.js/issues/2993 by checking that difference between DVRWindow.start and currentTime reported by video element isn't bigger than 1 year (could be even less, I think). This way, if for some reason currentElement is reported incorrectly (in our case whenever this happens it always points to year 1970), stream won't jump to very beginning.